### PR TITLE
fix CoreDNS not being able to resolve external CNAME targets

### DIFF
--- a/scripts/coredns-prod.yml
+++ b/scripts/coredns-prod.yml
@@ -22,6 +22,7 @@
                       connect_timeout 200
                       read_timeout 200
               }
+              forward . 8.8.8.8 8.8.4.4
           }
 
     - name: Create systemd service for coredns


### PR DESCRIPTION
fix CoreDNS not being able to resolve the CNAME target cname.vercel-dns.com, because it had no forwarding configured. The forward plugin enables CoreDNS to forward queries it can't answer to upstream DNS servers (Google's DNS in this case).