### PR TITLE
add redis fallthrough to handle notimp for https records

### DIFF
--- a/scripts/coredns-prod.yml
+++ b/scripts/coredns-prod.yml
@@ -21,6 +21,7 @@
                       ttl 10
                       connect_timeout 200
                       read_timeout 200
+                      fallthrough
               }
               forward . 8.8.8.8 8.8.4.4
           }

--- a/scripts/coredns-prod.yml
+++ b/scripts/coredns-prod.yml
@@ -12,6 +12,7 @@
         dest: "{{ app_path }}//Corefile"
         content: |
           . {
+              any
               log
               health :8053
               errors


### PR DESCRIPTION
logs:
```
udp 45 true 1220" NOTIMP qr,aa,cd 45 0.001788979s
Jul 03 13:12:37 sfc-admin-1 coredns[3064271]: [INFO] 203.117.83.245:41229 - 7972 "HTTPS IN docs.soranova.ai. udp 34 false 512" NOTIMP qr,aa 34 0.001488011s
Jul 03 13:12:37 sfc-admin-1 coredns[3064271]: [INFO] 203.117.83.180:47725 - 11999 "HTTPS IN docs.soranova.ai. udp 45 true 1220" NOTIMP qr,aa,cd 45 0.001620116s
Jul 03 13:12:37 sfc-admin-1 coredns[3064271]: [INFO] 203.117.83.244:41301 - 50534 "HTTPS IN docs.soranova.ai. udp 45 true 1220" NOTIMP qr,aa,cd 45 0.001353844s
Jul 03 13:12:37 sfc-admin-1 coredns[3064271]: [INFO] 203.117.83.180:45994 - 6952 "HTTPS IN docs.soranova.ai. udp 34 false 512" NOTIMP qr,aa 34 0.001882859s
Jul 03 13:12:37 sfc-admin-1 coredns[3064271]: [INFO] 203.117.83.244:40013 - 53864 "HTTPS IN docs.soranova.ai. udp 34 false 512" NOTIMP qr,aa 34 0.001766435s
```
What's happening:
Modern DNS clients (browsers, nslookup) query for HTTPS records (Type 65) first
CoreDNS Redis plugin doesn't support HTTPS record types
CoreDNS responds with NOTIMP (Not Implemented) with aa flag (Authoritative Answer)
Client stops here because CoreDNS claims to be authoritative but can't handle the query
The key issue: CoreDNS is acting authoritative (aa flag) for domains it has in Redis, but only supports basic record types (A, CNAME, NS, TXT, etc.), not modern ones like HTTPS.

We need to configure CoreDNS to NOT be authoritative for unsupported record types.