### PR TITLE
fix: delete_subdomain only deletes the named subdomain (was wiping the zone)

### DIFF
--- a/app/controllers/api/v1/zones_controller.rb
+++ b/app/controllers/api/v1/zones_controller.rb
@@ -160,7 +160,7 @@ class Api::V1::ZonesController < Api::ApiController
   # Use callbacks to share common setup or constraints between actions.
 
   def zone_params
-    params.require(:zone).permit(:name, :data, :record_name)
+    params.require(:zone).permit(:name, :data, :record_name, :subdomain)
   end
 
   def mx_params

--- a/app/models/dns_zone.rb
+++ b/app/models/dns_zone.rb
@@ -157,15 +157,26 @@ class DnsZone < ApplicationRecord
                             ttl: '300')
   end
 
+  # FIXED 2026-05-02: original implementation ignored the subdomain param and
+  # destroyed the entire zone (records + Redis key + DB row). Catastrophic on
+  # a multi-tenant DNS store — incident on 2026-05-01 took out clawstation.ai
+  # and h.briobots.ai zones via two innocent-looking delete-record calls.
+  # This rewrite deletes only the records named by params[:subdomain] within
+  # the zone and refreshes Redis for that one record name, mirroring the
+  # delete_acme_challenge shape.
   def self.delete_subdomain(params)
     zone = DnsZone.find_by(name: params[:name])
     return false if zone.nil?
 
-    zone.dns_records.destroy_all
+    subdomain = params[:subdomain].to_s.presence
+    return false if subdomain.blank?
 
-    redis = Redis.new(host: zone.redis_host)
-    redis.del("#{zone.name}.")
-    zone.destroy
+    records = zone.dns_records.where(name: subdomain)
+    return false if records.empty?
+
+    records.destroy_all
+    zone.update_redis(subdomain)
+    true
   end
 
   def self.create_acme_challenge(params)

--- a/spec/models/dns_zone_spec.rb
+++ b/spec/models/dns_zone_spec.rb
@@ -150,4 +150,46 @@ RSpec.describe DnsZone, type: :model do
       ENV['DEFAULT_PRIMARY_NS'] = cached_val if cached_val
     end
   end
+
+  # Regression suite for the 2026-05-01 incident — old delete_subdomain
+  # ignored the subdomain param and destroyed the entire zone.
+  describe '.delete_subdomain' do
+    let(:zone) { DnsZone.create!(name: 'example.com', redis_host: 'localhost') }
+    let(:redis_mock) { instance_double(Redis, hdel: 1, hset: 1) }
+
+    before do
+      allow(Redis).to receive(:new).with(host: 'localhost').and_return(redis_mock)
+      zone.dns_records.create!(name: 'foo', record_type: DnsRecord::A, data: '1.1.1.1', ttl: '300')
+      zone.dns_records.create!(name: 'bar', record_type: DnsRecord::A, data: '2.2.2.2', ttl: '300')
+    end
+
+    it 'deletes ONLY the named subdomain, leaving zone + sibling records intact' do
+      result = DnsZone.delete_subdomain(name: 'example.com', subdomain: 'foo')
+
+      expect(result).to be(true)
+      expect(DnsZone.find_by(name: 'example.com')).to eq(zone)             # zone survives
+      expect(zone.dns_records.where(name: 'foo')).to be_empty               # subdomain gone
+      expect(zone.dns_records.where(name: 'bar')).not_to be_empty           # sibling intact
+    end
+
+    it 'returns false (no-op) when the zone does not exist' do
+      expect(DnsZone.delete_subdomain(name: 'nope.example.com', subdomain: 'foo')).to be(false)
+    end
+
+    it 'returns false when subdomain param is missing or blank — DOES NOT delete the zone' do
+      expect(DnsZone.delete_subdomain(name: 'example.com')).to be(false)
+      expect(DnsZone.delete_subdomain(name: 'example.com', subdomain: '')).to be(false)
+
+      # The catastrophic regression we are guarding against: an old version
+      # of this method ignored :subdomain and destroyed the zone wholesale.
+      expect(DnsZone.find_by(name: 'example.com')).to eq(zone)
+      expect(zone.dns_records.count).to eq(2)
+    end
+
+    it 'returns false when no records match the subdomain — does not delete the zone' do
+      expect(DnsZone.delete_subdomain(name: 'example.com', subdomain: 'nonexistent')).to be(false)
+      expect(DnsZone.find_by(name: 'example.com')).to eq(zone)
+      expect(zone.dns_records.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Why

`DnsZone.delete_subdomain` ignored `params[:subdomain]` and ran `dns_records.destroy_all` + `redis.del` + `zone.destroy` — every call destroyed the entire zone. Strong params on the controller also didn't permit `:subdomain`, so even clients that passed it correctly had it silently stripped.

**2026-05-01 incident:** two innocent-looking delete-record calls from clawstation/briobots took out `clawstation.ai` and `h.briobots.ai` zones for ~1 hour. Manually reconstructed via API restore + `DnsZone#refresh`. All 40 ClawStation stations re-verified clean by the existing 14-point station sanity script.

## What

- `app/models/dns_zone.rb` — rewrite `delete_subdomain` to delete only records matching `params[:subdomain]` within the named zone, then `update_redis(subdomain)`. Mirrors the `delete_acme_challenge` shape.
- `app/controllers/api/v1/zones_controller.rb` — add `:subdomain` to `zone_params` permit list.
- `spec/models/dns_zone_spec.rb` — regression suite: deletes only the subdomain (zone + siblings intact), no-op on missing zone, no-op on blank/missing subdomain (the catastrophic regression we're guarding against), no-op on non-matching subdomain.

## Test plan

- [x] `bundle exec rspec spec/models/dns_zone_spec.rb` → 20 examples, 0 failures (4 new)
- [x] Full suite: `138 examples, 11 failures` — the 11 are pre-existing redis-mock failures on `main` (134/11 baseline), unchanged by this PR.
- [x] Patched method has been live on infra01 since 2026-05-02 (in-place edit + backup at `app/models/dns_zone.rb.bak.<ts>`). Roundtrip add+delete verified on `onboard.clawstation.ai` (deletes one record, leaves zone + siblings intact).
- [x] Restoration script for the destroyed zones executed cleanly; `clawstation.ai` (54 records) + `h.briobots.ai` (5 records) recreated and resolving via local CoreDNS + 1.1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)