### PR TITLE
Fix acme-challenge create/delete vs Redis sync

### DIFF
--- a/app/controllers/api/v1/zones_controller.rb
+++ b/app/controllers/api/v1/zones_controller.rb
@@ -15,8 +15,11 @@ class Api::V1::ZonesController < Api::ApiController
     zone = DnsZone.find_by(name: zone_params[:name])
 
     challenge_name = zone_params[:record_name].presence || '_acme-challenge'
+    # TTL=1 so the global `cache` plugin in Corefile only holds these records
+    # (and their NXDOMAIN siblings) for ~1s — otherwise the present→validate
+    # window during ACME flows can serve a stale cached value to the CA.
     record = zone.dns_records.create(name: challenge_name, record_type: DnsRecord::TXT, data: zone_params[:data],
-                                     ttl: '300')
+                                     ttl: '1')
     if record.save
       zone.refresh
       render json: { id: record.id, name: record.name, data: record.data }, status: :created
@@ -41,13 +44,14 @@ class Api::V1::ZonesController < Api::ApiController
   def delete_acme_challenge
     zone = DnsZone.find_by(name: zone_params[:name])
     challenge_name = zone_params[:record_name].presence || '_acme-challenge'
-    record = zone.dns_records.find_by(name: challenge_name, record_type: DnsRecord::TXT)
-    if record.destroy
-      zone.update_redis(record.name)
-      render json: { id: record.id, name: record.name, data: record.data }, status: :ok
-    else
-      render json: { errors: record.errors.full_messages }, status: :unprocessable_entity
-    end
+    # `find_by` returned only the first match, leaving siblings behind when
+    # a previous lego run ordered SAN+wildcard against the same record_name.
+    # Destroy ALL matches and do a full zone.refresh so Redis is in sync —
+    # update_redis(name) was a per-name partial sync that didn't write the
+    # zero-records case (Redis kept the deleted record's old value).
+    destroyed = zone.dns_records.where(name: challenge_name, record_type: DnsRecord::TXT).destroy_all
+    zone.refresh
+    render json: { count: destroyed.size, name: challenge_name }, status: :ok
   end
 
   def delete_subdomain


### PR DESCRIPTION
## Summary

Two bugs in `Api::V1::ZonesController#create_acme_challenge` and `#delete_acme_challenge` were silently breaking `lego --dns exec` flows when ordering multiple SANs against the same zone (e.g. apex + wildcard):

- **TTL=300 on the challenge record** + global `cache 30` in our Corefile = up to 5min effective negative cache for `_acme-challenge.<zone>`, so the present→validate→cleanup→present-next-SAN window served stale data to the CA. Lowered to **TTL=1** — challenge records are ephemeral, no reason to cache them.

- **`delete_acme_challenge` used `find_by` + `update_redis(name)`** — only destroyed the first matching record (lego with multiple SANs against the same apex creates multiple TXT records), and `update_redis(name)` is a per-name partial sync that silently kept the destroyed row's old value in Redis. Replaced with `where(...).destroy_all` + a full `zone.refresh`.

## Verification

End-to-end wildcard cert flow against real Let's Encrypt production:

```
lego --dns exec --dns.exec.hook=/usr/local/bin/coredns-ui-dns-hook.sh \
  --domains 'stg.clawstation.ai' --domains '*.stg.clawstation.ai' run
```

→ Both authorizations validated (`The server validated our request`), cert issued. SAN list: `stg.clawstation.ai, *.stg.clawstation.ai`.

## Test plan

- [ ] Run lego against an unused subdomain — confirm cert issuance succeeds
- [ ] Confirm DELETE removes ALL matching TXTs (test by POST-ing two values to same record_name then DELETE-ing)
- [ ] Confirm dig sees TTL=1 on returned TXT record after create

🤖 Generated with [Claude Code](https://claude.com/claude-code)