### PR TITLE
fix(api): permit :subdomain so delete_subdomain doesn't 404 every call

### DIFF
--- a/app/controllers/api/v1/zones_controller.rb
+++ b/app/controllers/api/v1/zones_controller.rb
@@ -160,7 +160,12 @@ class Api::V1::ZonesController < Api::ApiController
   # Use callbacks to share common setup or constraints between actions.
 
   def zone_params
-    params.require(:zone).permit(:name, :data, :record_name)
+    # :subdomain is read by DnsZone.delete_subdomain to scope the deletion to
+    # a single leaf record. Without it on the permit list, strong-params strips
+    # it before the model sees it, the method short-circuits with `return false
+    # if subdomain.blank?`, and the controller renders 404 'Zone not found'
+    # for every call — silently leaking DNS records on every station teardown.
+    params.require(:zone).permit(:name, :data, :record_name, :subdomain)
   end
 
   def mx_params

--- a/spec/requests/api/v1/zones_spec.rb
+++ b/spec/requests/api/v1/zones_spec.rb
@@ -119,5 +119,26 @@ RSpec.describe 'Api::V1::Zones', type: :request do # rubocop:disable Metrics/Blo
              }
       expect(DnsZone.find_by(name: 'sub.example.com')).to eq(nil)
     end
+
+    # Regression: delete_subdomain was 404'ing in production because :subdomain
+    # was missing from the strong-params permit list, so the model never saw
+    # it and returned false. Every DNS delete call was silently leaking the
+    # leaf A record. See ClawStation #318.
+    it 'should delete a single leaf record within an apex zone' do
+      apex = DnsZone.find_by(name: 'example.com') || DnsZone.create!(name: 'example.com')
+      apex.dns_records.create!(name: 'leaf-to-delete', record_type: DnsRecord::A, data: '10.0.0.1', ttl: '300')
+      apex.dns_records.create!(name: 'leaf-to-keep',   record_type: DnsRecord::A, data: '10.0.0.2', ttl: '300')
+
+      delete '/api/v1/zones/delete_subdomain',
+             params: { zone: { name: 'example.com', subdomain: 'leaf-to-delete' } }.to_json,
+             headers: {
+               'Authorization' => @api_token.token,
+               'Content-Type' => 'application/json'
+             }
+
+      expect(response).to have_http_status(:ok)
+      expect(apex.dns_records.where(name: 'leaf-to-delete')).to be_empty
+      expect(apex.dns_records.where(name: 'leaf-to-keep')).not_to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary

Strong-params permit list in `ZonesController#zone_params` is missing `:subdomain`, so `DnsZone.delete_subdomain` always reads `params[:subdomain] == nil`, short-circuits via `return false if subdomain.blank?`, and the controller renders `404 'Zone not found'` for every call. Production has been silently leaking DNS records on every consumer-side teardown since the model was rewritten on 2026-05-02.

## Impact

Audit of the production Redis hash on infra01 for `clawstation.ai.` shows ~115 orphan A records — months of "successful" station teardowns that never actually deleted their DNS record.

Tracking: [ajeygore/clawstation#318](https://github.com/ajeygore/clawstation/issues/318)

## Test plan

- [x] Added regression request spec `delete a single leaf record within an apex zone` covering the post-2026-05-02 leaf-deletion behavior
- [ ] After merge + deploy: rerun a real DELETE against an orphan and confirm 200 + record removal from both sqlite and Redis