### PR TITLE
fix(model): scope delete_subdomain to a leaf — stop nuking the whole zone

### DIFF
--- a/app/models/dns_zone.rb
+++ b/app/models/dns_zone.rb
@@ -157,15 +157,25 @@ class DnsZone < ApplicationRecord
                             ttl: '300')
   end
 
+  # SAFE: deletes only the records named by params[:subdomain] within the zone
+  # and refreshes Redis for that one name. The previous implementation ignored
+  # the :subdomain param entirely and destroyed the WHOLE zone (records +
+  # Redis hash + DB row), which took out clawstation.ai on 2026-05-01 and
+  # 2026-05-28. If you're tempted to "simplify" this back to destroy_all on
+  # the zone, please re-read the postmortem first.
   def self.delete_subdomain(params)
     zone = DnsZone.find_by(name: params[:name])
     return false if zone.nil?
 
-    zone.dns_records.destroy_all
+    subdomain = params[:subdomain].to_s.presence
+    return false if subdomain.blank?
 
-    redis = Redis.new(host: zone.redis_host)
-    redis.del("#{zone.name}.")
-    zone.destroy
+    records = zone.dns_records.where(name: subdomain)
+    return false if records.empty?
+
+    records.destroy_all
+    zone.update_redis(subdomain)
+    true
   end
 
   def self.create_acme_challenge(params)


### PR DESCRIPTION
## Summary

DnsZone.delete_subdomain on main reads params[:name] and silently destroys the entire zone (records + Redis hash + DB row), ignoring params[:subdomain]. This took clawstation.ai DNS down on **2026-05-01** AND again on **2026-05-28**.

The 2026-05-02 fix was hot-patched on the infra01 box but never PR'd back to main. When I deployed main on 2026-05-28 (for the strong-params permit-list fix in #11), the destructive version came back. On the very next delete_subdomain API call, zone 7 + all 194 records were wiped.

This commit ports the 2026-05-02 hot-patch back to main, with a load-bearing comment so the destructive shape can't accidentally come back a third time.

## The fix

- Read params[:subdomain], scope destroy_all to records named by it.
- zone.update_redis(subdomain) refreshes Redis for that single name only.
- Return false (404) when :subdomain is missing.
- The zone, its SOA/NS records, and sibling A records are never touched.

## Test plan

- [x] Manual verification on infra01: 1 leaf record deleted, sibling records and zone row intact, Redis hash retained other entries.
- [ ] Regression spec to be added in a follow-up.