### PR TITLE
fix(acme): TTL=1 challenge records + destroy sibling matches; capture prod hot-patches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,7 @@ gem 'omniauth-google-oauth2'
 
 gem 'httparty'
 gem 'pry'
+
+# Extracted from the Ruby stdlib in 3.4 — pin explicitly so bundler doesn't
+# warn / fail to resolve it as a transitive default gem.
+gem 'tsort', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,6 +447,7 @@ GEM
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
+    tsort (0.2.0)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -515,6 +516,7 @@ DEPENDENCIES
   stimulus-rails
   tailwindcss-rails
   tapioca
+  tsort (~> 0.2.0)
   turbo-rails
   tzinfo-data
   watchman

--- a/app/controllers/api/v1/zones_controller.rb
+++ b/app/controllers/api/v1/zones_controller.rb
@@ -15,8 +15,11 @@ class Api::V1::ZonesController < Api::ApiController
     zone = DnsZone.find_by(name: zone_params[:name])
 
     challenge_name = zone_params[:record_name].presence || '_acme-challenge'
+    # TTL=1 so the global `cache` plugin in Corefile only holds these records
+    # (and their NXDOMAIN siblings) for ~1s — otherwise the present→validate
+    # window during ACME flows can serve a stale cached value to the CA.
     record = zone.dns_records.create(name: challenge_name, record_type: DnsRecord::TXT, data: zone_params[:data],
-                                     ttl: '300')
+                                     ttl: '1')
     if record.save
       zone.refresh
       render json: { id: record.id, name: record.name, data: record.data }, status: :created
@@ -41,13 +44,14 @@ class Api::V1::ZonesController < Api::ApiController
   def delete_acme_challenge
     zone = DnsZone.find_by(name: zone_params[:name])
     challenge_name = zone_params[:record_name].presence || '_acme-challenge'
-    record = zone.dns_records.find_by(name: challenge_name, record_type: DnsRecord::TXT)
-    if record.destroy
-      zone.update_redis(record.name)
-      render json: { id: record.id, name: record.name, data: record.data }, status: :ok
-    else
-      render json: { errors: record.errors.full_messages }, status: :unprocessable_entity
-    end
+    # `find_by` returned only the first match, leaving siblings behind when
+    # a previous lego run ordered SAN+wildcard against the same record_name.
+    # Destroy ALL matches and do a full zone.refresh so Redis is in sync —
+    # update_redis(name) was a per-name partial sync that didn't write the
+    # zero-records case (Redis kept the deleted record's old value).
+    destroyed = zone.dns_records.where(name: challenge_name, record_type: DnsRecord::TXT).destroy_all
+    zone.refresh
+    render json: { count: destroyed.size, name: challenge_name }, status: :ok
   end
 
   def delete_subdomain

--- a/spec/requests/api/v1/zones_spec.rb
+++ b/spec/requests/api/v1/zones_spec.rb
@@ -100,7 +100,11 @@ RSpec.describe 'Api::V1::Zones', type: :request do # rubocop:disable Metrics/Blo
       expect(zone.dns_records.count).to eq(4)
     end
 
-    it 'should delete the subdomain and return a success status' do
+    # Safety property (see #12): delete_subdomain MUST NOT destroy a zone. When
+    # called without a :subdomain it returns 404 and leaves everything intact.
+    # The old destructive behavior (this used to assert the whole zone was
+    # gone) took clawstation.ai down twice — do not restore it.
+    it 'does NOT destroy the zone when called without a :subdomain' do
       post '/api/v1/zones/create_subdomain',
            params: @subdomain_params.to_json,
            headers: {
@@ -108,16 +112,19 @@ RSpec.describe 'Api::V1::Zones', type: :request do # rubocop:disable Metrics/Blo
              'Content-Type' => 'application/json'
            }
       expect(response).to have_http_status(:created)
-      expect(DnsZone.exists?(name: 'sub.example.com')).to be_truthy
       zone = DnsZone.find_by(name: 'sub.example.com')
       expect(zone.dns_records.count).to eq(4)
+
       delete '/api/v1/zones/delete_subdomain',
              params: @subdomain_params.to_json,
              headers: {
                'Authorization' => @api_token.token,
                'Content-Type' => 'application/json'
              }
-      expect(DnsZone.find_by(name: 'sub.example.com')).to eq(nil)
+
+      expect(response).to have_http_status(:not_found)
+      expect(DnsZone.find_by(name: 'sub.example.com')).not_to be_nil
+      expect(zone.reload.dns_records.count).to eq(4)
     end
 
     # Regression: delete_subdomain was 404'ing in production because :subdomain


### PR DESCRIPTION
## Summary

Captures the remaining uncommitted production hot-patches from `infra01:/home/deploy/coredns_ui` into source control. These lived only on the box — the exact pattern that caused the 2026-05-28 clawstation.ai zone wipe (a deploy overwrote an uncommitted fix). Getting them into main so the next deploy is safe.

1. **create_acme_challenge** — TTL `1` instead of `300`. The Corefile `cache` plugin otherwise holds the challenge (and NXDOMAIN siblings) long enough that the present→validate window can serve a stale value to the CA.
2. **delete_acme_challenge** — `find_by` only destroyed the first match, leaving siblings when lego ordered SAN+wildcard under the same record_name. Now `where(...).destroy_all` + full `zone.refresh`.
3. **Gemfile** — pin `tsort ~> 0.2.0` (extracted from Ruby 3.4 stdlib).
4. **spec** — rewrote the `delete_subdomain` request spec: it used to assert the whole zone was destroyed (the destructive behavior fixed in #12). Now asserts the safety property — a subdomain-less call returns 404 and leaves the zone + records intact.

## Test plan

- [x] `bundle exec rspec` — 135 examples, 0 failures (with local Redis)